### PR TITLE
Wprowadzono zaznaczanie strefy poruszania dla jednostek

### DIFF
--- a/PanzerGeneral2_0/Controls/Grid/HexBoard.xaml
+++ b/PanzerGeneral2_0/Controls/Grid/HexBoard.xaml
@@ -12,7 +12,7 @@
         <hx:HexList Name="Board" Margin="5"
                     RowCount="8" ColumnCount="15" >
             <hx:HexList.ItemContainerStyle>
-                <Style TargetType="{x:Type hx:HexItem}">
+                <Style TargetType="{x:Type items:HexPoint}">
                     <Setter Property="Grid.Row" Value="{Binding Path=Point.Y}"/>
                     <Setter Property="Grid.Column" Value="{Binding Path=Point.X}"/>
                     <Setter Property="BorderThickness" Value="1.5"/>

--- a/PanzerGeneral2_0/Controls/Grid/HexPoint.cs
+++ b/PanzerGeneral2_0/Controls/Grid/HexPoint.cs
@@ -3,7 +3,7 @@ using PanzerGeneral2_0.Controls.Units;
 
 namespace PanzerGeneral2_0.Controls.Grid
 {
-    public class HexPoint
+    public class HexPoint : HexItem
     {
 
         public enum HexPointTerrainInfo
@@ -14,13 +14,13 @@ namespace PanzerGeneral2_0.Controls.Grid
         }
 
         public Unit Unit { get; set; }
-
         public HexPointTerrainInfo Terrain { get; set; }
         public string ImageSource { get; set; }
         public IntPoint Point { get; set; }
 
         public HexPoint(IntPoint point, string imageSource) 
         {
+            this.DataContext = this;
             this.Point = point;
             this.ImageSource = imageSource;
         }
@@ -39,9 +39,11 @@ namespace PanzerGeneral2_0.Controls.Grid
         /**
          Odbiera jednostkę HexItem'owi
          */
-        public void unbindUnitFromHex()
+        public Unit unbindUnitFromHex()
         {
+            Unit tempUnit = this.Unit;
             this.Unit = null;
+            return tempUnit;
         }
     }
 }

--- a/PanzerGeneral2_0/Factories/UnitFactory.cs
+++ b/PanzerGeneral2_0/Factories/UnitFactory.cs
@@ -1,9 +1,5 @@
 ﻿using PanzerGeneral2_0.Controls.Units;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PanzerGeneral2_0.Factories
 {


### PR DESCRIPTION
Pierwsza wersja zaznaczania strefy poruszania dla jednostek - niepoprawne wyświetlanie przeniesionej jednostki, prawa strona mapy nie działa